### PR TITLE
Install On-Demand Scanning API extraction helper

### DIFF
--- a/gke-deploy/Dockerfile
+++ b/gke-deploy/Dockerfile
@@ -10,6 +10,7 @@ FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
 RUN gcloud -q components install kubectl
 RUN gcloud -q components install gsutil
 RUN gcloud -q components install kustomize
+RUN gcloud -q components install local-extract
 RUN apk -q --no-cache add gettext
 
 COPY --from=build-env /gke-deploy /


### PR DESCRIPTION
Install the gcloud component On-Demand Scanning API extraction helper (local-extract) as this is used to get container vulnerability scan results from Artifact Registry. This is useful to have in the cloudbuild container if you need to check for vulnerabilities before deploying to GKE.